### PR TITLE
feat: Implement room participation and listing APIs

### DIFF
--- a/server/src/routes/rooms.test.ts
+++ b/server/src/routes/rooms.test.ts
@@ -22,7 +22,15 @@ vi.mock('@prisma/client', () => {
       findUnique: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
-    }
+    },
+    user: { // Added for participant invitation tests
+      findUnique: vi.fn(),
+    },
+    roomParticipant: { // Extended for participant invitation tests
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      findMany: vi.fn(), // For /me/rooms
+    },
     // Add other models and methods as needed
   };
   return { PrismaClient: vi.fn(() => mockPrismaClient) };
@@ -45,20 +53,32 @@ describe('Room and Video Routes', () => {
   let app: FastifyInstance;
   let prismaMock: any;
 
-  const mockUser = { userId: 'testUserId', username: 'testUser' };
+  const mockUserInviter = { userId: 'inviterUserId', username: 'inviterUser' };
+  const mockUserToInvite = { userId: 'toInviteUserId', username: 'toInviteUser' };
+  const mockAnotherParticipant = { userId: 'anotherParticipantId', username: 'anotherParticipant' };
   const mockRoomId = 'room123';
   const mockVideoId = 'video123';
 
+
   beforeEach(async () => {
     app = Fastify();
-    prismaMock = new PrismaClient();
+    prismaMock = new PrismaClient(); // This is the mock instance
     app.register(roomRoutes);
+
+    // Override the authenticate mock for specific tests if needed,
+    // otherwise the default mock (providing mockUserInviter) will be used.
+    // This is crucial for testing scenarios involving different authenticated users.
+    // The default mock is set up to use mockUserInviter:
+    (app.authenticate as any) = vi.fn(async (request: FastifyRequest, reply: FastifyReply) => {
+        (request as any).user = mockUserInviter;
+    });
+
     await app.ready();
   });
 
   afterEach(async () => {
     await app.close();
-    vi.resetAllMocks();
+    vi.resetAllMocks(); // This resets all vi mocks, including Prisma and authenticate
   });
 
   // --- Room Routes ---
@@ -225,6 +245,155 @@ describe('Room and Video Routes', () => {
             url: `/rooms/nonexistentroom/videos`,
           });
         expect(response.statusCode).toBe(404);
+    });
+  });
+
+  // --- Participant Invitation Routes ---
+  describe('POST /rooms/:roomId/participants', () => {
+    const inviterUserId = mockUserInviter.userId;
+    const userToInviteId = mockUserToInvite.userId;
+
+    it('should successfully invite a user to a room', async () => {
+      prismaMock.room.findUnique.mockResolvedValue({ id: mockRoomId, name: 'Test Room' });
+      prismaMock.roomParticipant.findUnique
+        .mockResolvedValueOnce({ userId: inviterUserId, roomId: mockRoomId }) // Inviter is participant
+        .mockResolvedValueOnce(null); // User to invite is NOT yet participant
+      prismaMock.user.findUnique.mockResolvedValue({ id: userToInviteId, username: 'ToInvite' }); // User to invite exists
+      const newParticipant = { roomId: mockRoomId, userId: userToInviteId, user: { id: userToInviteId, username: 'ToInvite' } };
+      prismaMock.roomParticipant.create.mockResolvedValue(newParticipant);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/rooms/${mockRoomId}/participants`,
+        payload: { userId: userToInviteId },
+        // headers: { authorization: 'Bearer inviterToken' } // authenticate is mocked
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(response.json()).toEqual(newParticipant);
+      expect(prismaMock.roomParticipant.create).toHaveBeenCalledWith({
+        data: { roomId: mockRoomId, userId: userToInviteId },
+        include: { user: { select: { id: true, username: true } } },
+      });
+    });
+
+    it('should return 403 if inviter is not a participant', async () => {
+      prismaMock.room.findUnique.mockResolvedValue({ id: mockRoomId, name: 'Test Room' });
+      prismaMock.roomParticipant.findUnique.mockResolvedValue(null); // Inviter is NOT participant
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/rooms/${mockRoomId}/participants`,
+        payload: { userId: userToInviteId },
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.json().error).toBe('You are not authorized to invite users to this room');
+    });
+
+    it('should return 404 if user to invite does not exist', async () => {
+      prismaMock.room.findUnique.mockResolvedValue({ id: mockRoomId, name: 'Test Room' });
+      prismaMock.roomParticipant.findUnique.mockResolvedValue({ userId: inviterUserId, roomId: mockRoomId }); // Inviter is participant
+      prismaMock.user.findUnique.mockResolvedValue(null); // User to invite does NOT exist
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/rooms/${mockRoomId}/participants`,
+        payload: { userId: 'nonExistentUserId' },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json().error).toBe('User to invite not found');
+    });
+
+    it('should return 409 if user to invite is already a participant', async () => {
+      prismaMock.room.findUnique.mockResolvedValue({ id: mockRoomId, name: 'Test Room' });
+      prismaMock.roomParticipant.findUnique
+        .mockResolvedValueOnce({ userId: inviterUserId, roomId: mockRoomId }) // Inviter is participant
+        .mockResolvedValueOnce({ userId: userToInviteId, roomId: mockRoomId }); // User to invite IS ALREADY participant
+
+      prismaMock.user.findUnique.mockResolvedValue({ id: userToInviteId, username: 'ToInvite' }); // User to invite exists
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/rooms/${mockRoomId}/participants`,
+        payload: { userId: userToInviteId },
+      });
+
+      expect(response.statusCode).toBe(409);
+      expect(response.json().error).toBe('User is already a participant in this room');
+    });
+
+    it('should return 404 if room does not exist', async () => {
+      prismaMock.room.findUnique.mockResolvedValue(null); // Room does NOT exist
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/rooms/nonExistentRoomId/participants`,
+        payload: { userId: userToInviteId },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json().error).toBe('Room not found');
+    });
+
+     it('should return 400 if userId to invite is not provided', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: `/rooms/${mockRoomId}/participants`,
+        payload: {}, // Missing userId
+      });
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toBe('User ID to invite is required');
+    });
+  });
+
+  // --- User's Rooms Route ---
+  describe('GET /me/rooms', () => {
+    const currentUserId = mockUserInviter.userId; // Assuming this user is making the request
+
+    it('should return a list of rooms the user is a participant of', async () => {
+      const userRooms = [
+        { roomId: 'room1', userId: currentUserId, room: { id: 'room1', name: 'Room Alpha', _count: { participants: 2 } } },
+        { roomId: 'room2', userId: currentUserId, room: { id: 'room2', name: 'Room Beta', _count: { participants: 1 } } },
+      ];
+      prismaMock.roomParticipant.findMany.mockResolvedValue(userRooms);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/me/rooms',
+        // headers: { authorization: 'Bearer userToken' } // authenticate is mocked
+      });
+
+      expect(response.statusCode).toBe(200);
+      const responseData = response.json();
+      expect(responseData).toHaveLength(2);
+      expect(responseData[0]).toEqual(userRooms[0].room);
+      expect(responseData[1]).toEqual(userRooms[1].room);
+      expect(prismaMock.roomParticipant.findMany).toHaveBeenCalledWith({
+        where: { userId: currentUserId },
+        include: { room: { include: { _count: { select: { participants: true } } } } },
+        orderBy: { room: { createdAt: 'desc' } },
+      });
+    });
+
+    it('should return an empty list if the user is not in any rooms', async () => {
+      prismaMock.roomParticipant.findMany.mockResolvedValue([]); // User is in no rooms
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/me/rooms',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual([]);
+    });
+
+    it('should trigger authenticate middleware', async () => {
+        // This test mostly ensures the route is protected and uses the mocked user
+        prismaMock.roomParticipant.findMany.mockResolvedValue([]);
+        await app.inject({ method: 'GET', url: '/me/rooms' });
+        expect(app.authenticate).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Adds new API endpoints for managing room participation:

1.  `POST /rooms/:roomId/participants`: Allows an authenticated participant of a room to add another existing user to that room.
    - Validates that the inviting user is a participant.
    - Validates that the room and the user to be invited exist.
    - Prevents adding a user who is already a participant.
    - Returns the new room participant details on success.

2.  `GET /me/rooms`: Allows an authenticated user to retrieve a list of rooms they are a participant in.
    - Returns room details including name, creation date, and current participant count.

Includes unit tests for both endpoints, covering success scenarios and various error conditions.